### PR TITLE
feat: Use dynamic year for 'fromDateOnwards'

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -108,7 +108,7 @@ export default function HomePage() {
         </div>
     );
 
-    const currentYear = new Date().getFullYear();
+    const currentYear = useMemo(() => new Date().getFullYear(), []);
 
     return (
         <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
Replaces the hardcoded year in the 'Recently Added' stats card with the current year, making the statistic dynamic and accurate.