### PR TITLE
Add Touch Navigation and Autoplay to Carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@axiomhq/react": "^0.1.6",
                 "@prisma/client": "^6.16.3",
                 "@types/bcryptjs": "^2.4.6",
+                "@use-gesture/react": "^10.3.1",
                 "bcryptjs": "^3.0.2",
                 "better-auth": "^1.4.5",
                 "ioredis": "^5.9.2",
@@ -3732,6 +3733,24 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@use-gesture/core": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+            "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+            "license": "MIT"
+        },
+        "node_modules/@use-gesture/react": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+            "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+            "license": "MIT",
+            "dependencies": {
+                "@use-gesture/core": "10.3.1"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0"
+            }
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@axiomhq/react": "^0.1.6",
         "@prisma/client": "^6.16.3",
         "@types/bcryptjs": "^2.4.6",
+        "@use-gesture/react": "^10.3.1",
         "bcryptjs": "^3.0.2",
         "better-auth": "^1.4.5",
         "ioredis": "^5.9.2",


### PR DESCRIPTION
This submission adds touch navigation, a sliding animation, and an autoplay feature to the stats carousel. It also hides the arrow buttons on mobile devices to improve the user experience.

Fixes #355

---
*PR created automatically by Jules for task [5770520125086732109](https://jules.google.com/task/5770520125086732109) started by @jorbush*