### PR TITLE
Fix Mobile Form Zoom

### DIFF
--- a/components/comment/comment-form.tsx
+++ b/components/comment/comment-form.tsx
@@ -73,7 +73,7 @@ export function CommentForm({ reviewId }: CommentFormProps) {
                     rows={4}
                     value={comment}
                     onChange={(e) => setComment(e.target.value)}
-                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
                     disabled={isSubmitting}
                     required
                 />

--- a/components/review/review-form.tsx
+++ b/components/review/review-form.tsx
@@ -209,7 +209,7 @@ export function ReviewForm({
                     rows={4}
                     value={text}
                     onChange={(e) => setText(e.target.value)}
-                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
                     disabled={isSubmitting}
                 />
             </div>


### PR DESCRIPTION
This change prevents mobile browsers from zooming in on the review and comment forms by increasing the font size of the textareas.

Fixes #366

---
*PR created automatically by Jules for task [16915031912007658231](https://jules.google.com/task/16915031912007658231) started by @jorbush*