### PR TITLE
Update Text Size for Small Screens in Forms

### DIFF
--- a/components/comment/comment-form.tsx
+++ b/components/comment/comment-form.tsx
@@ -63,7 +63,7 @@ export function CommentForm({ reviewId }: CommentFormProps) {
             <div>
                 <label
                     htmlFor="comment"
-                    className="text-foreground mb-2 block text-xs font-semibold sm:text-base"
+                    className="text-foreground mb-2 block text-sm font-semibold"
                 >
                     {tRP('yourComment')}
                 </label>
@@ -73,7 +73,7 @@ export function CommentForm({ reviewId }: CommentFormProps) {
                     rows={4}
                     value={comment}
                     onChange={(e) => setComment(e.target.value)}
-                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                     disabled={isSubmitting}
                     required
                 />

--- a/components/review/review-form.tsx
+++ b/components/review/review-form.tsx
@@ -142,7 +142,7 @@ export function ReviewForm({
             onSubmit={editProps ? handleSubmitPatch : handleSubmitPost}
         >
             <fieldset>
-                <legend className="text-foreground mb-2 block text-xs font-semibold sm:text-base">
+                <legend className="text-foreground mb-2 block text-sm font-semibold">
                     {t('yourRating')}
                 </legend>
                 <div className="flex flex-wrap items-center gap-4 sm:gap-6">
@@ -199,7 +199,7 @@ export function ReviewForm({
             <div>
                 <label
                     htmlFor="comment"
-                    className="text-foreground mb-2 block text-xs font-semibold sm:text-base"
+                    className="text-foreground mb-2 block text-sm font-semibold"
                 >
                     {t('yourReview')}
                 </label>
@@ -209,7 +209,7 @@ export function ReviewForm({
                     rows={4}
                     value={text}
                     onChange={(e) => setText(e.target.value)}
-                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                     disabled={isSubmitting}
                 />
             </div>


### PR DESCRIPTION
This change increases the font size of labels in the review and comment forms to match the input fields on small screens, improving the visual consistency of the forms.

Fixes #369

---
*PR created automatically by Jules for task [4963980641146804385](https://jules.google.com/task/4963980641146804385) started by @jorbush*