### PR TITLE
Add domains to CORS and Better Auth configuration

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 import { NextRequest, NextResponse } from 'next/server';
+import { FOSLOG_URL, FOSLOG_COM_URL, FOLSOG_WWW_URL } from '@/lib/constants';
 
 const handler = toNextJsHandler(auth);
 
@@ -14,7 +15,9 @@ const getCorsHeaders = (request: NextRequest) => {
     const origin = request.headers.get('Origin');
     const allowedOrigins = [
         'http://localhost:3000',
-        'https://foslog.vercel.app',
+        FOSLOG_URL,
+        FOSLOG_COM_URL,
+        FOLSOG_WWW_URL,
     ];
 
     if (origin) {

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,7 +1,11 @@
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { prisma } from '@/lib/prisma';
-import { FOSLOG_URL } from '@/lib/constants';
+import {
+    FOSLOG_URL,
+    FOSLOG_COM_URL,
+    FOLSOG_WWW_URL,
+} from '@/lib/constants';
 
 export const auth = betterAuth({
     database: prismaAdapter(prisma, {
@@ -35,6 +39,8 @@ export const auth = betterAuth({
     trustedOrigins: [
         'http://localhost:3000',
         FOSLOG_URL,
+        FOSLOG_COM_URL,
+        FOLSOG_WWW_URL,
         ...(process.env.VERCEL_URL
             ? [`https://${process.env.VERCEL_URL}`]
             : []),

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,5 @@
 export const LOCALES = ['en', 'es', 'ca'] as const;
 export type Locale = (typeof LOCALES)[number];
 export const FOSLOG_URL = 'https://foslog.vercel.app';
+export const FOSLOG_COM_URL = 'https://foslog.com';
+export const FOLSOG_WWW_URL = 'https://www.folsog.com';


### PR DESCRIPTION
The user wanted to add `foslog.com` and `www.folsog.com` to the CORS middleware and Better Auth configuration.

I have:
1.  Added `FOSLOG_COM_URL` and `FOLSOG_WWW_URL` to `lib/constants.ts`.
2.  Updated `app/api/auth/[...all]/route.ts` to include these in the `allowedOrigins` array for CORS headers.
3.  Updated `lib/auth/auth.ts` to include these in the `trustedOrigins` array for Better Auth.

Note: `www.folsog.com` was included exactly as requested in the prompt, despite being a likely typo for `www.foslog.com`, to ensure strict adherence to the request. I also refactored the existing hardcoded `https://foslog.vercel.app` string to use the `FOSLOG_URL` constant.

Fixes #398

---
*PR created automatically by Jules for task [18324980359406401186](https://jules.google.com/task/18324980359406401186) started by @jorbush*