### PR TITLE
Add --archive=tgz for Vercel deployments GitHub workflows

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -21,7 +21,7 @@ jobs:
               run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
             - name: Deploy Project Artifacts to Vercel
               id: deploy_vercel
-              run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+              run: echo "url=$(vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
             - name: Comment PR
               uses: actions/github-script@v7
               with:

--- a/.github/workflows/vercel-deployment.yml
+++ b/.github/workflows/vercel-deployment.yml
@@ -18,4 +18,4 @@ jobs:
             - name: Build Project Artifacts
               run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
             - name: Deploy Project Artifacts to Vercel
-              run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Added the `--archive=tgz` flag to the `vercel deploy` command in both `vercel-deployment.yml` and `preview-deployment.yml` GitHub workflow files. This follows Vercel's best practices for CI/CD deployments to improve upload reliability and performance.

Fixes #401

---
*PR created automatically by Jules for task [14192803017548031134](https://jules.google.com/task/14192803017548031134) started by @jorbush*