### PR TITLE
Change media check in ReviewModal to GET request

### DIFF
--- a/components/modal/review-modal.tsx
+++ b/components/modal/review-modal.tsx
@@ -98,14 +98,15 @@ export default function ReviewModal() {
         setError(null);
 
         try {
-            const response = await fetch('/api/media', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    selectedMedia,
-                }),
+            const url = new URL('/api/media', window.location.origin);
+            url.searchParams.append('title', selectedMedia.title);
+            url.searchParams.append('type', selectedMedia.type);
+            if (selectedMedia.year) {
+                url.searchParams.append('year', selectedMedia.year.toString());
+            }
+
+            const response = await fetch(url.toString(), {
+                method: 'GET',
             });
 
             if (!response.ok) {

--- a/tests/components/modal/review-modal.test.tsx
+++ b/tests/components/modal/review-modal.test.tsx
@@ -126,10 +126,12 @@ describe('ReviewModal', () => {
 
         // 5. Verify API Call
         await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledWith('/api/media', expect.objectContaining({
-                method: 'POST',
-                body: expect.stringContaining('"title":"Test Movie"'),
-            }));
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/api/media?title=Test+Movie&type=film&year=2023'),
+                expect.objectContaining({
+                    method: 'GET',
+                })
+            );
         });
 
         // 6. Verify Step 2 rendered


### PR DESCRIPTION
The user reported that `handleNext` in `ReviewModal` was making a `POST` request to `/api/media` when it should be a `GET` request. 

I have:
1. Added a `GET` handler to `app/api/media/route.ts` that retrieves media by title, type, and year from query parameters, and also checks if the user has already reviewed that media.
2. Updated `handleNext` in `components/modal/review-modal.tsx` to use this new `GET` endpoint, passing parameters via `URLSearchParams`.
3. Updated `tests/components/modal/review-modal.test.tsx` to verify that `handleNext` now correctly makes a `GET` request with the expected parameters.

`submitReview` continues to use `POST` to ensure the media is created in the database if it doesn't already exist.

Fixes #410

---
*PR created automatically by Jules for task [4975176268630170484](https://jules.google.com/task/4975176268630170484) started by @jorbush*