### PR TITLE
Add v0.5.0 release blog post

### DIFF
--- a/_blog/ca/releases/foslog-v0-5-0.md
+++ b/_blog/ca/releases/foslog-v0-5-0.md
@@ -1,0 +1,53 @@
+---
+title: "Foslog v0.5.0 - L'Actualització de Comunitat i Refinament"
+date: "2026-03-02"
+category: "releases"
+description: "La versió 0.5.0 ja és aquí, introduint funcions socials amb el nou sistema de seguidors, edició de ressenyes, valoracions de mitja estrella i importants optimitzacions de rendiment amb triggers de base de dades."
+---
+
+# Presentem Foslog v0.5.0
+
+Estem emocionats d'anunciar el llançament de **Foslog v0.5.0**! Aquesta actualització se centra en aprofundir l'experiència de la comunitat i refinar les funcions principals que utilitzes cada dia. Des del sistema de seguidors tan sol·licitat fins a la precisió de les valoracions de mitja estrella i els massius guanys de rendiment interns, la v0.5.0 fa que Foslog sigui més ràpida, més social i més precisa.
+
+## Què hi ha de nou
+
+### Comunitat i Social
+- **Sistema de Seguidors**: Ara pots seguir i deixar de seguir altres usuaris! Mantingues un seguiment dels teus ressenyadors preferits i mira la seva darrera activitat. També hem afegit un nou Modal de Seguidors per gestionar fàcilment les teves connexions.
+- **Edició i Eliminació de Ressenyes**: Has fet una falta d'ortografia o has canviat d'opinió? Ara pots editar o eliminar les teves ressenyes existents.
+- **Gestió de Comentaris**: Ara tens la capacitat d'eliminar comentaris d'una ressenya, donant-te més control sobre les discussions en les teves publicacions.
+
+### Precisió i UI
+- **Ressenyes de Mitja Estrella**: De vegades 4 estrelles no són suficients, però 5 són massa. Ara pots valorar contingut amb una precisió de mitja estrella.
+- **Nou Carrusel d'Estadístiques**: Hem implementat un nou carrusel elegant per a les targetes d'estadístiques en pantalles petites, fent que sigui més fàcil digerir les teves dades des de qualsevol lloc.
+- **Correccions en l'Experiència Mòbil**: Hem estandarditzat les altures de les targetes i hem corregit el molest problema del zoom en els formularis mòbils augmentant la mida de la font en les entrades petites.
+- **Refinaments Visuals**: Busca el nou logotip de JAM al peu de pàgina i la interfície de les targetes de mitjans millorada per a un aspecte més polit.
+
+### Rendiment i Arquitectura
+- **Triggers de Base de Dades**: Hem mogut els càlculs estadístics pesats als triggers de PostgreSQL. Això significa que les estadístiques globals i els totals s'actualitzen de manera instantània i eficient en segon pla.
+- **Caché de Redis**: Les estadístiques globals ara es guarden a la caché amb Redis, reduint significativament la càrrega de la base de dades i accelerant les transicions de pàgina.
+- **Integració amb Axiom**: Hem integrat Axiom per a una millor monitorització i observabilitat, ajudant-nos a detectar i corregir problemes més ràpid que mai.
+- **Diagrames d'Arquitectura**: Hem afegit nous diagrames d'arquitectura i de flux de treball al repositori per documentar millor com funciona Foslog internament.
+
+### Usuari i SEO
+- **Gestió del Compte**: Ara pots eliminar el teu compte directament des del modal de configuració. També hem millorat la fiabilitat de les actualitzacions del nom d'usuari i la imatge de perfil.
+- **SEO i Metadades**: Hem realitzat millores significatives en la nostra gestió de SEO i metadades, fent que sigui més fàcil que les teves ressenyes es trobin i es comparteixin a la xarxa.
+- **Internacionalització**: S'han afegit més etiquetes localitzades, incloent-hi correccions per a les etiquetes "sèries" vs "sèrie" en diferents idiomes.
+
+## Changelog Complet
+
+Per a una llista detallada de tots els canvis, pots veure el [changelog complet a GitHub](https://github.com/JAM-Productions/foslog/compare/v0.4.0...v0.5.0).
+
+## Col·laboradors
+
+Un gran agraïment als nostres col·laboradors per aquest llançament:
+
+- @jorbush
+- @mriverre8
+- @mykytakrasnov (Benvingut al nostre nou col·laborador!)
+- @Copilot
+- @google-labs-jules
+- @dependabot
+
+---
+
+*Tens comentaris o suggeriments? Ens encantaria saber de tu a jamproductionsdev@gmail.com*

--- a/_blog/en/releases/foslog-v0-5-0.md
+++ b/_blog/en/releases/foslog-v0-5-0.md
@@ -1,0 +1,53 @@
+---
+title: "Foslog v0.5.0 - The Community & Refinement Update"
+date: "2026-03-02"
+category: "releases"
+description: "Version 0.5.0 is here, introducing social features with the new following system, review editing, half-star ratings, and significant performance optimizations with database triggers."
+---
+
+# Introducing Foslog v0.5.0
+
+We are thrilled to announce the release of **Foslog v0.5.0**! This update is all about deepening the community experience and refining the core features you use every day. From the highly requested following system to the precision of half-star ratings and massive under-the-hood performance gains, v0.5.0 makes Foslog faster, more social, and more precise.
+
+## What's New
+
+### Community & Social
+- **Following System**: You can now follow and unfollow other users! Keep track of your favorite reviewers and see their latest activity. We've also added a new Follow Modal to easily manage your connections.
+- **Review Editing & Deletion**: Made a typo or changed your mind? You can now edit or delete your existing reviews.
+- **Comment Management**: You now have the ability to delete comments from a review, giving you more control over the discussions on your posts.
+
+### Precision & UI
+- **Half-Star Reviews**: Sometimes 4 stars isn't enough, but 5 is too many. You can now rate media with half-star precision.
+- **New Stats Carousel**: We've implemented a sleek new carousel for statistics cards on small screens, making it easier to digest your data on the go.
+- **Mobile Experience Fixes**: We've standardized card heights and fixed the annoying mobile form zoom issue by increasing font sizes on small inputs.
+- **Visual Refinements**: Look out for the new JAM logo in the footer and improved media card UI for a more polished look.
+
+### Performance & Architecture
+- **Database Triggers**: We've moved heavy statistical calculations to PostgreSQL triggers. This means global stats and totals are updated instantly and efficiently in the background.
+- **Redis Caching**: Global stats are now cached with Redis, significantly reducing database load and speeding up page transitions.
+- **Axiom Integration**: We've integrated Axiom for better logging and observability, helping us catch and fix issues faster than ever.
+- **Architecture Diagrams**: We've added new architecture and workflow diagrams to the repository to better document how Foslog works under the hood.
+
+### User & SEO
+- **Account Management**: You can now delete your account directly from the settings modal. We've also improved the reliability of username and profile image updates.
+- **SEO & Metadata**: We've made significant improvements to our SEO and metadata handling, making it easier for your reviews to be found and shared across the web.
+- **Internationalization**: More localized labels have been added, including fixes for "series" vs "serie" labels across different languages.
+
+## Full Changelog
+
+For a detailed list of all changes, you can view the [full changelog on GitHub](https://github.com/JAM-Productions/foslog/compare/v0.4.0...v0.5.0).
+
+## Contributors
+
+A huge thank you to our contributors for this release:
+
+- @jorbush
+- @mriverre8
+- @mykytakrasnov (Welcome to our newest contributor!)
+- @Copilot
+- @google-labs-jules
+- @dependabot
+
+---
+
+*Have feedback or suggestions? We'd love to hear from you at jamproductionsdev@gmail.com*

--- a/_blog/es/releases/foslog-v0-5-0.md
+++ b/_blog/es/releases/foslog-v0-5-0.md
@@ -1,0 +1,53 @@
+---
+title: "Foslog v0.5.0 - La Actualización de Comunidad y Refinamiento"
+date: "2026-03-02"
+category: "releases"
+description: "La versión 0.5.0 ya está aquí, introduciendo funciones sociales con el nuevo sistema de seguidores, edición de reseñas, valoraciones de media estrella y optimizaciones de rendimiento con triggers de base de datos."
+---
+
+# Presentamos Foslog v0.5.0
+
+¡Estamos emocionados de anunciar el lanzamiento de **Foslog v0.5.0**! Esta actualización se centra en profundizar la experiencia de la comunidad y refinar las funciones principales que utilizas cada día. Desde el sistema de seguidores tan solicitado hasta la precisión de las valoraciones de media estrella y los masivos beneficios de rendimiento internos, la v0.5.0 hace que Foslog sea más rápida, más social y más precisa.
+
+## Qué hay de nuevo
+
+### Comunidad y Social
+- **Sistema de Seguidores**: ¡Ahora puedes seguir y dejar de seguir a otros usuarios! Mantén un seguimiento de tus reseñadores favoritos y mira su última actividad. También hemos añadido un nuevo Modal de Seguidores para gestionar fácilmente tus conexiones.
+- **Edición y Eliminación de Reseñas**: ¿Hiciste una falta de ortografía o cambiaste de opinión? Ahora puedes editar o eliminar tus reseñas existentes.
+- **Gestión de Comentarios**: Ahora tienes la capacidad de eliminar comentarios de una reseña, dándote más control sobre las discusiones en tus publicaciones.
+
+### Precisión y UI
+- **Reseñas de Media Estrella**: A veces 4 estrellas no son suficientes, pero 5 son demasiadas. Ahora puedes valorar contenido con una precisión de media estrella.
+- **Nuevo Carrusel de Estadísticas**: Hemos implementado un nuevo carrusel elegante para las tarjetas de estadísticas en pantallas pequeñas, haciendo que sea más fácil digerir tus datos desde cualquier lugar.
+- **Correcciones en la Experiencia Móvil**: Hemos estandarizado las alturas de las tarjetas y hemos corregido el molesto problema del zoom en los formularios móviles aumentando el tamaño de la fuente en las entradas pequeñas.
+- **Refinamientos Visuales**: Busca el nuevo logotipo de JAM en el pie de página y la interfaz de las tarjetas de medios mejorada para un aspecto más pulido.
+
+### Rendimiento y Arquitectura
+- **Triggers de Base de Datos**: Hemos movido los cálculos estadísticos pesados a los triggers de PostgreSQL. Esto significa que las estadísticas globales y los totales se actualizan de forma instantánea y eficiente en segundo plano.
+- **Caché de Redis**: Las estadísticas globales ahora se guardan en la caché con Redis, reduciendo significativamente la carga de la base de datos y acelerando las transiciones de página.
+- **Integración con Axiom**: Hemos integrado Axiom para un mejor registro y observabilidad, ayudándonos a detectar y corregir problemas más rápido que nunca.
+- **Diagramas de Arquitectura**: Hemos añadido nuevos diagramas de arquitectura y de flujo de trabajo al repositorio para documentar mejor cómo funciona Foslog internamente.
+
+### Usuario y SEO
+- **Gestión de la Cuenta**: Ahora puedes eliminar tu cuenta directamente desde el modal de configuración. También hemos mejorado la fiabilidad de las actualizaciones del nombre de usuario y la imagen de perfil.
+- **SEO y Metadatos**: Hemos realizado mejoras significativas en nuestra gestión de SEO y metadatos, haciendo que sea más fácil que tus reseñas se encuentren y se compartan en la red.
+- **Internacionalización**: Se han añadido más etiquetas localizadas, incluyendo correcciones para las etiquetas "series" vs "serie" en diferentes idiomas.
+
+## Changelog Completo
+
+Para una lista detallada de todos los cambios, puedes ver el [changelog completo en GitHub](https://github.com/JAM-Productions/foslog/compare/v0.4.0...v0.5.0).
+
+## Colaboradores
+
+Un gran agradecimiento a nuestros colaboradores por este lanzamiento:
+
+- @jorbush
+- @mriverre8
+- @mykytakrasnov (¡Bienvenido a nuestro nuevo colaborador!)
+- @Copilot
+- @google-labs-jules
+- @dependabot
+
+---
+
+*¿Tienes comentarios o sugerencias? Nos encantaría saber de ti en jamproductionsdev@gmail.com*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foslog",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foslog",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@axiomhq/js": "^1.3.1",
         "@axiomhq/logging": "^0.1.6",


### PR DESCRIPTION
This change adds the v0.5.0 release blog post to Foslog in English, Spanish, and Catalan. The content is based on the v0.5.0 changelog and summarizes the key community features, UI refinements, and performance optimizations introduced in this version. 

Additionally, this PR ensures that the version in `package-lock.json` is correctly synchronized with `package.json` at version 0.5.0.

Fixes #432

---
*PR created automatically by Jules for task [16277564748479849936](https://jules.google.com/task/16277564748479849936) started by @jorbush*