### PR TITLE
Add cursor-pointer to import modal tabs

### DIFF
--- a/components/modal/import-reviews-modal.tsx
+++ b/components/modal/import-reviews-modal.tsx
@@ -328,7 +328,11 @@ export default function ImportReviewsModal() {
                                     activeTab === tab
                                         ? 'text-foreground'
                                         : 'text-muted-foreground hover:text-foreground'
-                                } ${isImporting ? 'cursor-not-allowed opacity-50' : ''} `}
+                                } ${
+                                    isImporting
+                                        ? 'cursor-not-allowed opacity-50'
+                                        : 'cursor-pointer'
+                                } `}
                             >
                                 {t(`tabs.${tab}`)}
                                 {activeTab === tab && (


### PR DESCRIPTION
This PR adds the missing `cursor-pointer` utility class to the tabs in the Import Reviews modal. It also ensures that the cursor changes to `not-allowed` when the tabs are disabled during an active import, improving the overall user experience. Unrelated changes to `package-lock.json` were avoided.

Fixes #439

---
*PR created automatically by Jules for task [9736953881757051102](https://jules.google.com/task/9736953881757051102) started by @jorbush*