### PR TITLE
Add success toast when bookmarking a media

### DIFF
--- a/components/media/media-details.tsx
+++ b/components/media/media-details.tsx
@@ -87,6 +87,10 @@ export function MediaDetails({
                 }
 
                 router.refresh();
+                showToast(
+                    tToast(prevState ? 'bookmarkRemoved' : 'bookmarkAdded'),
+                    'success'
+                );
             } catch {
                 setOptimisticBookmarked(prevState);
                 showToast(tToast('toggleBookmarkFailed'), 'error');

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -282,6 +282,8 @@
         "imageUpdated": "Foto de perfil actualitzada correctament!",
         "imageUpdateFailed": "Error al actualitzar la foto de perfil. Si us plau intenta-ho de nou.",
         "fetchUsersFailed": "Error al obtenir els usuaris. Si us plau, torna-ho a provar.",
+        "bookmarkAdded": "Contingut guardat correctament!",
+        "bookmarkRemoved": "Contingut eliminat de guardats!",
         "toggleBookmarkFailed": "Error al actualitzar el teu marcador. Si us plau, torna-ho a provar.",
         "mediaRemovedFromList": "Mitjà eliminat de la llista amb èxit!",
         "mediaRemoveFromListFailed": "Error al eliminar el mitjà de la llista. Si us plau, torna-ho a intentar."

--- a/messages/en.json
+++ b/messages/en.json
@@ -282,6 +282,8 @@
         "imageUpdated": "Profile picture updated successfully!",
         "imageUpdateFailed": "Failed to update profile picture. Please try again.",
         "fetchUsersFailed": "Failed to fetch users. Please try again.",
+        "bookmarkAdded": "Media bookmarked successfully!",
+        "bookmarkRemoved": "Media removed from bookmarks!",
         "toggleBookmarkFailed": "Failed to update your bookmark. Please try again.",
         "mediaRemovedFromList": "Media removed from list successfully!",
         "mediaRemoveFromListFailed": "Failed to remove media from list. Please try again."

--- a/messages/es.json
+++ b/messages/es.json
@@ -282,6 +282,8 @@
         "imageUpdated": "Foto de perfil actualizada correctamente!",
         "imageUpdateFailed": "Fallo al actualizar la foto de perfil. Por favor inténtalo de nuevo.",
         "fetchUsersFailed": "Error al obtener usuarios. Por favor inténtalo de nuevo.",
+        "bookmarkAdded": "¡Contenido guardado exitosamente!",
+        "bookmarkRemoved": "¡Contenido eliminado de guardados!",
         "toggleBookmarkFailed": "Error al actualizar tu marcador. Por favor inténtalo de nuevo.",
         "mediaRemovedFromList": "Medio eliminado de la lista exitosamente!",
         "mediaRemoveFromListFailed": "Error al eliminar el medio de la lista. Por favor inténtalo de nuevo."

--- a/tests/components/media/media-details.test.tsx
+++ b/tests/components/media/media-details.test.tsx
@@ -714,7 +714,7 @@ describe('MediaDetails - bookmarkMedia', () => {
         });
     });
 
-    it('calls router.refresh() on successful bookmark', async () => {
+    it('calls router.refresh() and shows success toast on successful bookmark', async () => {
         (global.fetch as vi.Mock).mockResolvedValue({ ok: true });
 
         render(
@@ -729,6 +729,26 @@ describe('MediaDetails - bookmarkMedia', () => {
 
         await waitFor(() => {
             expect(refresh).toHaveBeenCalled();
+            expect(showToast).toHaveBeenCalledWith('bookmarkAdded', 'success');
+        });
+    });
+
+    it('calls router.refresh() and shows success toast on successful unbookmark', async () => {
+        (global.fetch as vi.Mock).mockResolvedValue({ ok: true });
+
+        render(
+            <MediaDetails
+                media={mockMedia}
+                hasBookmarked={true}
+            />
+        );
+        const bookmarkButton = screen.getByTestId('bookmark-button');
+
+        await userEvent.click(bookmarkButton);
+
+        await waitFor(() => {
+            expect(refresh).toHaveBeenCalled();
+            expect(showToast).toHaveBeenCalledWith('bookmarkRemoved', 'success');
         });
     });
 


### PR DESCRIPTION
Added success toast notifications for bookmarking and unbookmarking media items. This provides immediate feedback to the user after a successful toggle operation. Updated localization files (en, es, ca) and added unit tests to ensure reliability.

Fixes #444

---
*PR created automatically by Jules for task [10733911538955137040](https://jules.google.com/task/10733911538955137040) started by @jorbush*